### PR TITLE
Add Maven build helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,18 @@ For the packets class. ty guys.
 https://github.com/CryptoMorin/XSeries
 (https://www.spigotmc.org/threads/xseries-xmaterial-xparticle-xsound-xpotion-titles-actionbar-etc.378136/)
 XSeries gives support for versions 1.13 - 1.16
+
+## Build and Run
+
+Use the helper scripts located in the `scripts` directory to build and launch the plugin.
+
+```bash
+# Install Maven (if not already installed)
+./scripts/install-maven.sh
+
+# Compile the project
+./scripts/build.sh
+
+# Run the resulting jar
+./scripts/start.sh
+```

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
+if ! command -v mvn >/dev/null 2>&1; then
+  "$SCRIPT_DIR/install-maven.sh"
+fi
+
+mvn clean package

--- a/scripts/install-maven.sh
+++ b/scripts/install-maven.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+if command -v mvn >/dev/null 2>&1; then
+  echo "Maven already installed"
+  exit 0
+fi
+
+apt-get update
+apt-get install -y maven

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
+if ! command -v mvn >/dev/null 2>&1; then
+  "$SCRIPT_DIR/install-maven.sh"
+fi
+
+# Build if jar doesn't exist
+declare -a jars=(target/*.jar build_out/*.jar build_out/*.war)
+JAR=""
+for f in "${jars[@]}"; do
+  if [ -f "$f" ]; then
+    JAR="$f"
+    break
+  fi
+done
+
+if [ -z "$JAR" ]; then
+  "$SCRIPT_DIR/build.sh"
+  for f in "${jars[@]}"; do
+    if [ -f "$f" ]; then
+      JAR="$f"
+      break
+    fi
+  done
+fi
+
+if [ -z "$JAR" ]; then
+  echo "Unable to find built jar"
+  exit 1
+fi
+
+java -jar "$JAR" "$@"


### PR DESCRIPTION
## Summary
- add scripts to install Maven, build the project and run the plugin
- document how to use the new helper scripts

## Testing
- `apt-get install -y maven`
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684005e63ee4832bb6047fdba44fdda9